### PR TITLE
Spark Notebook location fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ git clone https://github.com/47deg/spark-workshop.git && cd spark-workshop
 * Download Spark Notebook binary distribution:
 
 ```bash
-wget -O spark-notebook.tgz https://s3.eu-central-1.amazonaws.com/spark-notebook/tgz/spark-notebook-master-scala-2.10.4-spark-1.5.1-hadoop-2.2.0.tgz?max-keys=100000
+wget -O spark-notebook.zip https://s3.eu-central-1.amazonaws.com/spark-notebook/zip/spark-notebook-master-scala-2.10.4-spark-1.5.1-hadoop-2.2.0.zip?max-keys=100000
 ```
-* Decompress the downloaded file as `spark-notebook.tgz`:
+* Decompress the downloaded file as `spark-notebook.zip`:
 
 ```bash
-tar -zxvf spark-notebook.tgz
+unzip spark-notebook.zip
 ```
 
 * Rename the directory to make it more friendly:


### PR DESCRIPTION
This PR updates links to get sparkNotebook. It seems tgz file does not exist anymore so we need to download and force instructions to use a ZIP file instead.
There will be a PR in the future to upgrade this presentation to use Spark 2.0.2 but for now we are gonna give this workshop using spark 1.5, since all concepts shown here are the same in both versions.

@juanpedromoreno @raulraja could you please review? Thanks!